### PR TITLE
Update USART.c

### DIFF
--- a/AVR-Programming-Library/USART.c
+++ b/AVR-Programming-Library/USART.c
@@ -21,28 +21,28 @@
 #include <util/setbaud.h>
 
 void initUSART(void) {                                /* requires BAUD */
-  UBRR0H = UBRRH_VALUE;                        /* defined in setbaud.h */
-  UBRR0L = UBRRL_VALUE;
+  UBRRH = UBRRH_VALUE;                        /* defined in setbaud.h */
+  UBRRL = UBRRL_VALUE;
 #if USE_2X
-  UCSR0A |= (1 << U2X0);
+  UCSRA |= (1 << U2X);
 #else
-  UCSR0A &= ~(1 << U2X0);
+  UCSRA &= ~(1 << U2X);
 #endif
                                   /* Enable USART transmitter/receiver */
-  UCSR0B = (1 << TXEN0) | (1 << RXEN0);
-  UCSR0C = (1 << UCSZ01) | (1 << UCSZ00);   /* 8 data bits, 1 stop bit */
+  UCSRB = (1 << TXEN) | (1 << RXEN);
+  UCSRC = (1 << UCSZ1) | (1 << UCSZ0);   /* 8 data bits, 1 stop bit */
 }
 
 
 void transmitByte(uint8_t data) {
                                      /* Wait for empty transmit buffer */
-  loop_until_bit_is_set(UCSR0A, UDRE0);
-  UDR0 = data;                                            /* send data */
+  loop_until_bit_is_set(UCSRA, UDRE);
+  UDR = data;                                            /* send data */
 }
 
 uint8_t receiveByte(void) {
-  loop_until_bit_is_set(UCSR0A, RXC0);       /* Wait for incoming data */
-  return UDR0;                                /* return register value */
+  loop_until_bit_is_set(UCSRA, RXC);       /* Wait for incoming data */
+  return UDR;                                /* return register value */
 }
 
 


### PR DESCRIPTION
I have atmega8 and for that uC, when I tried to compile I got error:
UCSRA0A undeclared (first use in this function)
and same error messages for UBRR0H, UBRR0L, U2X0, UCSR0B, TXEN0, RXEN0, UCSZ01, UCSZ00, UDRE0, RXC0 & for UDR0.
So I updated the file by dropping all 0s. Now it works perfectly for atmega8.
I also have tested the modified code for atmega168p (which you have used in your Makefile) and it worked without any error.
I think you should add this updated file to your project :)
Thank you!