### PR TITLE
Correction to the while loop on the USART readString method

### DIFF
--- a/AVR-Programming-Library/USART.c
+++ b/AVR-Programming-Library/USART.c
@@ -60,7 +60,7 @@ void readString(char myString[], uint8_t maxLength) {
   char response;
   uint8_t i;
   i = 0;
-  while (i < (maxLength)) {                   /* prevent over-runs */
+  while (i < maxLength) {                   /* prevent over-runs */
     response = receiveByte();
     transmitByte(response);                                    /* echo */
     if (response == '\r') {                     /* enter marks the end */

--- a/AVR-Programming-Library/USART.c
+++ b/AVR-Programming-Library/USART.c
@@ -60,7 +60,7 @@ void readString(char myString[], uint8_t maxLength) {
   char response;
   uint8_t i;
   i = 0;
-  while (i < (maxLength - 1)) {                   /* prevent over-runs */
+  while (i < (maxLength)) {                   /* prevent over-runs */
     response = receiveByte();
     transmitByte(response);                                    /* echo */
     if (response == '\r') {                     /* enter marks the end */


### PR DESCRIPTION
The loop ended one cycle before the expected (max) length
